### PR TITLE
update okhttp due to CVE-2023-3635 vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The client is available in the [Maven Central Repository](https://mvnrepository.
     <dependency>
         <groupId>com.recombee</groupId>
         <artifactId>api-client</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
     </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.3</version>
+            <version>4.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/recombee/api_client/RecombeeClient.java
+++ b/src/main/java/com/recombee/api_client/RecombeeClient.java
@@ -97,7 +97,7 @@ public class RecombeeClient {
 
     final int BATCH_MAX_SIZE = 10000; //Maximal number of requests within one batch request
 
-    final String USER_AGENT = "recombee-java-api-client/4.1.0";
+    final String USER_AGENT = "recombee-java-api-client/4.1.1";
 
     private final OkHttpClient httpClient = new OkHttpClient();
 


### PR DESCRIPTION
Update the okhttp library to address the CVE-2023-3635 vulnerability introduced by its dependency, com.squareup.okio:okio.