### PR TITLE
Improve timeouts and exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-/target/
+target
+.classpath
+.project
+.settings

--- a/src/main/java/com/recombee/api_client/RecombeeClient.java
+++ b/src/main/java/com/recombee/api_client/RecombeeClient.java
@@ -949,7 +949,7 @@ public class RecombeeClient {
             return response.body().string();
         }
         catch (InterruptedIOException e) {
-            throw new ApiTimeoutException(request);
+            throw new ApiTimeoutException(request, e);
         }
         catch (IOException e) {
             e.printStackTrace();
@@ -1009,7 +1009,7 @@ public class RecombeeClient {
             throw new ResponseException(request, response.code(), response.body().string());
         } catch (IOException e) {
             e.printStackTrace();
-            throw new ResponseException(request, response.code(), "Failed to read the error from response");
+            throw new ResponseException(request, response.code(), "Failed to read the error from response", e);
         }
     }
 }

--- a/src/main/java/com/recombee/api_client/RecombeeClient.java
+++ b/src/main/java/com/recombee/api_client/RecombeeClient.java
@@ -917,6 +917,7 @@ public class RecombeeClient {
                 .connectTimeout(request.getTimeout(), TimeUnit.MILLISECONDS)
                 .readTimeout(request.getTimeout(), TimeUnit.MILLISECONDS)
                 .writeTimeout(request.getTimeout(), TimeUnit.MILLISECONDS)
+                .callTimeout(request.getTimeout() * 2, TimeUnit.MILLISECONDS)
                 .build();
 
 

--- a/src/main/java/com/recombee/api_client/exceptions/ApiException.java
+++ b/src/main/java/com/recombee/api_client/exceptions/ApiException.java
@@ -8,4 +8,8 @@ public class ApiException extends Exception {
     public ApiException(String message) {
         super(message);
     }
+
+    public ApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/recombee/api_client/exceptions/ApiTimeoutException.java
+++ b/src/main/java/com/recombee/api_client/exceptions/ApiTimeoutException.java
@@ -5,15 +5,15 @@ import com.recombee.api_client.api_requests.Request;
 /**
  * Exception thrown when a request is not processed within the timeout
  */
-public class ApiTimeoutException extends  ApiException {
+public class ApiTimeoutException extends ApiException {
 
     /**
      * Request that timed out
      */
     Request request;
 
-    public ApiTimeoutException(Request request) {
-        super(String.format("ApiTimeout: client did not get response within %s ms" , request.getTimeout()));
+    public ApiTimeoutException(Request request, Throwable cause) {
+        super(String.format("ApiTimeout: client did not get response within %s ms" , request.getTimeout()), cause);
         this.request = request;
     }
 

--- a/src/main/java/com/recombee/api_client/exceptions/ResponseException.java
+++ b/src/main/java/com/recombee/api_client/exceptions/ResponseException.java
@@ -5,7 +5,7 @@ import com.recombee.api_client.api_requests.Request;
 /**
  * Exception thrown when a request did not succeed (did not return 200 or 201)
  */
-public class ResponseException extends  ApiException {
+public class ResponseException extends ApiException {
 
     /**
      * Request which failed
@@ -17,7 +17,11 @@ public class ResponseException extends  ApiException {
     int statusCode;
 
     public ResponseException(Request request, int statusCode, String message) {
-        super(message);
+        this(request, statusCode, message, null);
+    }
+
+    public ResponseException(Request request, int statusCode, String message, Throwable cause) {
+        super(message, cause);
         this.request = request;
         this.statusCode = statusCode;
     }


### PR DESCRIPTION
Adds the cause to exceptions when catching/throwing errors.

Sets okhttp's callTimeout to ensure that requests are interrupted if they take too long.

Setting callTimeout() to 2x the actual timeout in an attempt to be careful about not impacting existing http/socket timeout behavior. And to only interrupt if it's taken an unreasonable length of time. This is also the ratio that okhttp uses in [their examples](https://github.com/square/okhttp/blob/e63f4baeb6065974cffb3c60ec4f992696e4ce10/samples/guide/src/main/java/okhttp3/recipes/ConfigureTimeouts.java#L31)